### PR TITLE
fix/#44 : 検索画面にある「動画の長さ」の最小値のつまみを固定

### DIFF
--- a/src/components/organisms/FilterPanel/index.tsx
+++ b/src/components/organisms/FilterPanel/index.tsx
@@ -105,7 +105,7 @@ export const FilterPanel = ({
   const handleDurationChange = (values: number[]) => {
     setFilters((prev) => ({
       ...prev,
-      duration: [values[0], values[1]],
+      duration: [0, values[1]],
     }));
   };
 
@@ -259,7 +259,7 @@ export const FilterPanel = ({
                 <Box px={2} pt={4} pb={2}>
                   <RangeSlider
                     aria-label={['最小時間', '最大時間']}
-                    value={filters.duration}
+                    value={[0, filters.duration[1]]}
                     min={0}
                     max={maxDuration}
                     onChange={handleDurationChange}
@@ -273,7 +273,7 @@ export const FilterPanel = ({
                 </Box>
 
                 <Flex justify="space-between" px={2}>
-                  <Text fontSize="sm">{formatTime(filters.duration[0])}</Text>
+                  <Text fontSize="sm">{formatTime(0)}</Text>
                   <Text fontSize="sm">{formatTime(filters.duration[1])}</Text>
                 </Flex>
               </AccordionPanel>


### PR DESCRIPTION
## 🔄 変更内容

<!-- 変更の概要を記載してください -->
検索画面にある「動画の長さの」バーの最小値である「0」から動かないように変更。

## 🎯 関連 Issue

<!-- 関連するIssueがあれば記載してください -->

- close #44 

## ✨ 変更点

<!-- 具体的な変更内容を箇条書きで記載してください -->

-
-
-

## 📸 スクリーンショット

<!-- UI変更がある場合は、変更前後のスクリーンショットを添付してください -->
<img width="1279" alt="スクリーンショット 2025-02-27 112742" src="https://github.com/user-attachments/assets/20726430-202a-402d-995c-4f6e0e9570fd" />

## ✅ 確認項目

- [ ] コードレビューを依頼する準備ができている
- [ ] テストを追加・更新した
- [ ] ドキュメントを更新した（必要な場合）
- [ ] CI が通過している
- [ ] コンフリクトがない

## 🔍 テスト項目

<!-- テストした内容を記載してください -->

- [ ]
- [ ]
- [ ]

## 📝 補足情報

<!-- レビュワーに伝えたい補足情報があれば記載してください -->
